### PR TITLE
Android Log Email Fix

### DIFF
--- a/www/js/services/shareLocalDBFile.ts
+++ b/www/js/services/shareLocalDBFile.ts
@@ -6,8 +6,8 @@ function localDBHelpers(fileName: string, fileExtension: string = '.txt') {
     return new Promise<void>((resolve, reject) => {
       let pathToFile, parentDirectory;
       if (window['cordova'].platformId == 'android') {
-        parentDirectory = window['cordova'].file.dataDirectory;
-        pathToFile = fileName;
+        parentDirectory = window['cordova'].file.dataDirectory.replace('files', 'databases')
+        pathToFile = parentDirectory.replace('file://', '') + fileName;
       } else if (window['cordova'].platformId == 'ios') {
         parentDirectory = window['cordova'].file.dataDirectory + '../';
         pathToFile = 'LocalDatabase/' + fileName;

--- a/www/js/services/shareLocalDBFile.ts
+++ b/www/js/services/shareLocalDBFile.ts
@@ -6,7 +6,7 @@ function localDBHelpers(fileName: string, fileExtension: string = '.txt') {
     return new Promise<void>((resolve, reject) => {
       let pathToFile, parentDirectory;
       if (window['cordova'].platformId == 'android') {
-        parentDirectory = window['cordova'].file.dataDirectory.replace('files', 'databases')
+        parentDirectory = window['cordova'].file.dataDirectory.replace('files', 'databases');
         pathToFile = parentDirectory.replace('file://', '') + fileName;
       } else if (window['cordova'].platformId == 'ios') {
         parentDirectory = window['cordova'].file.dataDirectory + '../';


### PR DESCRIPTION
Fixed the Android bug for new implementation of the log email by passing in an absolute path to `getFile()` instead of a relative one. 